### PR TITLE
Object with the Websocket handlers and test of the handlers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,8 +27,62 @@
       "devDependencies": {
         "chai": "^4.3.7",
         "mocha": "^10.2.0",
-        "nodemon": "^2.0.22"
+        "nodemon": "^2.0.22",
+        "sinon": "^15.0.4"
       }
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
+      "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz",
+      "integrity": "sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^2.0.0"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers/node_modules/@sinonjs/commons": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+      "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.0.tgz",
+      "integrity": "sha512-Bp8KUVlLp8ibJZrnvq2foVhP0IVX2CIprMJPK0vqGqgrDa0OHVKeZyBykqskkrdxV6yKBPmGasO8LVjAKR3Gew==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^2.0.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/samsam/node_modules/@sinonjs/commons": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+      "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/text-encoding": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
+      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
+      "dev": true
     },
     "node_modules/@types/node": {
       "version": "18.15.11",
@@ -1133,6 +1187,12 @@
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q=="
     },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true
+    },
     "node_modules/jake": {
       "version": "10.8.5",
       "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.5.tgz",
@@ -1162,6 +1222,12 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
+    },
     "node_modules/kareem": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.5.1.tgz",
@@ -1189,6 +1255,12 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "dev": true
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -1522,6 +1594,37 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
       "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
+    },
+    "node_modules/nise": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.4.tgz",
+      "integrity": "sha512-8+Ib8rRJ4L0o3kfmyVCL7gzrohyDe0cMFTBa2d364yIrEGMEoetznKJx899YxjybU6bL9SQkYPSBBs1gyYs8Xg==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^2.0.0",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
+    },
+    "node_modules/nise/node_modules/@sinonjs/commons": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+      "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/nise/node_modules/path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "dependencies": {
+        "isarray": "0.0.1"
+      }
     },
     "node_modules/node-gyp-build": {
       "version": "4.6.0",
@@ -1997,6 +2100,54 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/sinon": {
+      "version": "15.0.4",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-15.0.4.tgz",
+      "integrity": "sha512-uzmfN6zx3GQaria1kwgWGeKiXSSbShBbue6Dcj0SI8fiCNFbiUDqKl57WFlY5lyhxZVUKmXvzgG2pilRQCBwWg==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@sinonjs/samsam": "^8.0.0",
+        "diff": "^5.1.0",
+        "nise": "^5.1.4",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon/node_modules/diff": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
+      "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/sinon/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sinon/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
@@ -2406,6 +2557,63 @@
     }
   },
   "dependencies": {
+    "@sinonjs/commons": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
+      "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz",
+      "integrity": "sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^2.0.0"
+      },
+      "dependencies": {
+        "@sinonjs/commons": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+          "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+          "dev": true,
+          "requires": {
+            "type-detect": "4.0.8"
+          }
+        }
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.0.tgz",
+      "integrity": "sha512-Bp8KUVlLp8ibJZrnvq2foVhP0IVX2CIprMJPK0vqGqgrDa0OHVKeZyBykqskkrdxV6yKBPmGasO8LVjAKR3Gew==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^2.0.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      },
+      "dependencies": {
+        "@sinonjs/commons": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+          "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+          "dev": true,
+          "requires": {
+            "type-detect": "4.0.8"
+          }
+        }
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
+      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
+      "dev": true
+    },
     "@types/node": {
       "version": "18.15.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
@@ -3267,6 +3475,12 @@
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q=="
     },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true
+    },
     "jake": {
       "version": "10.8.5",
       "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.5.tgz",
@@ -3287,6 +3501,12 @@
         "argparse": "^2.0.1"
       }
     },
+    "just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
+    },
     "kareem": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.5.1.tgz",
@@ -3305,6 +3525,12 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "dev": true
     },
     "log-symbols": {
       "version": "4.1.0",
@@ -3535,6 +3761,39 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
       "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
+    },
+    "nise": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.4.tgz",
+      "integrity": "sha512-8+Ib8rRJ4L0o3kfmyVCL7gzrohyDe0cMFTBa2d364yIrEGMEoetznKJx899YxjybU6bL9SQkYPSBBs1gyYs8Xg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^2.0.0",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "@sinonjs/commons": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+          "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+          "dev": true,
+          "requires": {
+            "type-detect": "4.0.8"
+          }
+        },
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
     },
     "node-gyp-build": {
       "version": "4.6.0",
@@ -3875,6 +4134,43 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
           "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
           "dev": true
+        }
+      }
+    },
+    "sinon": {
+      "version": "15.0.4",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-15.0.4.tgz",
+      "integrity": "sha512-uzmfN6zx3GQaria1kwgWGeKiXSSbShBbue6Dcj0SI8fiCNFbiUDqKl57WFlY5lyhxZVUKmXvzgG2pilRQCBwWg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^3.0.0",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@sinonjs/samsam": "^8.0.0",
+        "diff": "^5.1.0",
+        "nise": "^5.1.4",
+        "supports-color": "^7.2.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
+          "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "",
   "main": "server.js",
   "scripts": {
-    "test": "mocha test",
+    "test": "mocha --recursive test",
     "devStart": "nodemon server.js"
   },
   "author": "",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "devDependencies": {
     "chai": "^4.3.7",
     "mocha": "^10.2.0",
-    "nodemon": "^2.0.22"
+    "nodemon": "^2.0.22",
+    "sinon": "^15.0.4"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",

--- a/server.js
+++ b/server.js
@@ -5,7 +5,7 @@
 nodemon can be acti
 */
 export{server};
-import {startWebsocketserver} from "./web_socket/handlers.js";
+import {startWebsocketserver, handlers} from "./web_socket/handlers.js";
 const port = 3000;
 
 import express from "express";

--- a/test/Jobtypes/matrix_multiplication/algorithmsTest.spec.js
+++ b/test/Jobtypes/matrix_multiplication/algorithmsTest.spec.js
@@ -1,5 +1,5 @@
 import{assert} from 'chai'
-import{matrix_mult_str} from "../../Jobtypes/matrix_multiplication/algorithms.js"
+import{matrix_mult_str} from "../../../Jobtypes/matrix_multiplication/algorithms.js"
 
 
 let matrix_mult=new Function('A','B',matrix_mult_str);

--- a/test/Jobtypes/matrix_multiplication/algorithmsTest.spec.js
+++ b/test/Jobtypes/matrix_multiplication/algorithmsTest.spec.js
@@ -51,6 +51,106 @@ let matrix_DC=[
 
 describe("algorithms",function(){
     describe("matrix_mult",function(){
+        it("matrix_mult should give matrix output of correct size (2x2 times 2X2)", function(){
+            let result=matrix_mult(matrix_A,matrix_B);
+            let resultRows=result.length;
+            let resultColumns=result[0].length;
+            let expectedRows=matrix_A.length;
+            let expectedColumns=matrix_B[0].length;
+            assert.equal(resultRows,expectedRows);
+            assert.equal(resultColumns,expectedColumns);
+
+        })
+        it("matrix_mult should give matrix output of correct size (3x4 times 4X3)", function(){
+            let result=matrix_mult(matrix_C,matrix_D);
+            let resultRows=result.length;
+            let resultColumns=result[0].length;
+            let expectedRows=matrix_C.length;
+            let expectedColumns=matrix_D[0].length;
+            assert.equal(resultRows,expectedRows);
+            assert.equal(resultColumns,expectedColumns);
+
+        })
+        it("matrix_mult should compute correctly for an instance of 2x2 matricies (AB)", function(){
+            let result=JSON.stringify(matrix_mult(matrix_A,matrix_B));
+            let expected=JSON.stringify(matrix_AB);
+            assert.equal(result,expected);
+
+        })
+        it("matrix_mult should compute correctly for an instance of 2x2 matricies (BA)", function(){
+            let result=JSON.stringify(matrix_mult(matrix_B,matrix_A));
+            let expected=JSON.stringify(matrix_BA);
+            assert.equal(result,expected);
+
+        })
+        it("matrix_mult should compute correctly for an instance of 3x4 and 4X3 matricies (CD)", function(){
+            let result=JSON.stringify(matrix_mult(matrix_C,matrix_D));
+            let expected=JSON.stringify(matrix_CD);
+            assert.equal(result,expected);
+        })
+        it("matrix_mult should compute correctly for an instance of 3X4 and 4X3 matricies (DC)", function(){
+            let result=JSON.stringify(matrix_mult(matrix_D,matrix_C));
+            let expected=JSON.stringify(matrix_DC);
+            assert.equal(result,expected);
+        })
+    })
+    
+})
+
+
+/*
+let matrix_mult=new Function('A','B',matrix_mult_str);
+
+let matrix_A = [
+    [1, 2],
+    [3, 4]
+];
+
+let matrix_B = [
+    [2, 0],
+    [1, 2]
+];
+
+let matrix_AB=[
+    [4, 4],
+    [10, 8]
+];
+let matrix_BA=[
+    [2, 4],
+    [7, 10]
+];
+
+let matrix_C=[
+    [1, -2, 8 , -4],
+    [4, -2, -9 , -1],
+    [5, 2, 1, 4]
+];
+
+let matrix_D=[
+    [1, 4, 5 ],
+    [-2, -2, 2],
+    [8, -9, 1],
+    [-4, -1, 4]
+];
+
+let matrix_CD=[
+    [85, -60, -7],
+    [-60 , 102, 3],
+    [-7 , 3, 46],
+]
+let matrix_DC=[
+    [42, 0, -23, 12],
+    [0 , 12, 4, 18],
+    [-23 , 4, 146, -19],
+    [12, 18, -19, 33]
+]
+
+
+
+
+
+describe("algorithms",function(){
+    describe("matrix_mult",function(){
         it("matrix_mult) should compute correctly for an instance of 2x2 matricies (AB)", function(){
             let result=JSON.stringify(matrix_mult(matrix_A,matrix_B));
             let expected=JSON.stringify(matrix_AB);
@@ -76,3 +176,4 @@ describe("algorithms",function(){
     })
     
 })
+*/

--- a/test/Jobtypes/matrix_multiplication/algorithmsTest.spec.js
+++ b/test/Jobtypes/matrix_multiplication/algorithmsTest.spec.js
@@ -1,5 +1,5 @@
 import{assert} from 'chai'
-import{matrix_mult_str} from "../Jobtypes/matrix_multiplication/algorithms.js"
+import{matrix_mult_str} from "../../Jobtypes/matrix_multiplication/algorithms.js"
 
 
 let matrix_mult=new Function('A','B',matrix_mult_str);

--- a/test/web_socket/handlersTest.spec.js
+++ b/test/web_socket/handlersTest.spec.js
@@ -1,0 +1,157 @@
+import {spy} from "sinon";
+import {assert as assertSinon} from "sinon"
+import {subtaskFeeder} from "../../Jobtypes/matrix_multiplication/taskFeed.js"
+import{JobQueue} from "../../Jobtypes/matrix_multiplication/jobQueue.js";
+import { WebSocket } from "ws";
+import { WebSocketServer } from "ws";
+import {arr, matrix_B} from "../../Jobtypes/matrix_multiplication/matrixSplit.js"
+
+let handlers={
+  JobQueue: JobQueue,
+  subtaskFeeder: subtaskFeeder,
+  ws: null,
+  sendSubtask: function sendSubtask(){
+                  //console.log("subtasklist tail:"+JobQueue.tail.subtaskList.tail);
+                  let next_task = handlers.subtaskFeeder(handlers.JobQueue,handlers.ws);
+                  handlers.ws.send(JSON.stringify(next_task));
+                },
+  messageHandler: function messageHandler(message){
+
+                    // Try is for if some one sends somehting which cannot be passed to JSON:
+                    try {
+                    let messageParse = JSON.parse(message);
+                    console.log("Message recieved about this job:");
+                    console.log(
+                      messageParse.jobId
+                      );
+                    } catch (e) {
+                    console.log(`Something went wrong with the recieved message: ${e.message}`);
+                    }
+
+                    try{
+                      handlers.sendSubtask();
+                    } catch (e){
+                    console.log(`Something went wrong with sending message to server: ${e.message}`);
+                    }
+                  },
+connectionHandler: function connectionHandler(ws){
+                      handlers.ws=ws
+                      console.log("New client connected");
+                      console.log("JobQueue: " + JobQueue);
+  
+                      if (JobQueue.size > 0) {
+                      
+                      handlers.sendSubtask(ws);
+                      } else {
+                      ws.send("0");
+                      }
+
+                     ws.on("message", handlers.messageHandler)
+                    }
+}
+
+
+describe("handlers", function(){
+  
+    let server,client;
+
+    describe("connectionHandler", function(){
+
+      beforeEach(function(done){
+        server= new WebSocketServer({ port: 8002 });
+        server.on('listening', function(){
+          client=new WebSocket('ws://localhost:8002')
+          client.on('open', function(){
+            done(); 
+          });
+        })
+      });
+
+      afterEach(function(done){
+            server.close(function(){
+              client.close();
+            });
+            done();
+          });
+      
+    it("should call console.log() twice on server connect (with empty JobQueue)", function(done){
+      let spyLog=spy(console,"log");
+      JobQueue.size=0;
+      handlers.connectionHandler(client);
+      assertSinon.calledTwice(spyLog);
+      done();
+    });
+
+    it("should send \"0\" if JobQueue.size==0", function(done){
+      let spy_send=spy(client,"send");
+      JobQueue.size=0;
+      handlers.connectionHandler(client);
+      assertSinon.calledWithExactly(spy_send,"0");
+      done();
+    });
+
+    it("should call sendSubask if JobQueue.size>0", function(done){
+      let spy_send=spy(handlers,"sendSubtask");
+      JobQueue.size=1;
+      handlers.connectionHandler(client);
+      assertSinon.calledOnce(spy_send);
+      done();
+    });
+  });
+
+  
+  describe("sendSubtask",function(){
+
+    beforeEach(function(done){
+      server= new WebSocketServer({ port: 8002 });
+      server.on('listening', function(){
+        client=new WebSocket('ws://localhost:8002')
+        client.on('open', function(){
+          done(); 
+        });
+      })
+    });
+
+    afterEach(function(done){
+      server.close(function(){
+        client.close();
+      });
+      done();
+        });
+
+
+    it("should call subtaskFeeder", function(done){
+      handlers.ws=client;
+      let spy_subtaskFeeder=spy(handlers,"subtaskFeeder");
+      handlers.sendSubtask();
+      done()
+      assertSinon.calledOnce(spy_subtaskFeeder);
+    })
+  })
+
+  describe("subtaskFeeder",function(){
+    beforeEach(function(done){
+      server= new WebSocketServer({ port: 8002 });
+      server.on('listening', function(){
+        client=new WebSocket('ws://localhost:8002')
+        client.on('open', function(){
+          done(); 
+        });
+      });
+    });
+    this.afterEach(function(done){
+      done();
+    })
+    it("should call JobQueue.deQueue() if tail-job is empty of subtasks", function(){
+         JobQueue.enQueue(1, matrix_B);
+         for (let index = 0; index < arr.length; index++) {
+         JobQueue.head.subtaskList.enQueue(JobQueue.head.jobId, index, arr[index]);
+         JobQueue.head.numOfTasks++;
+         }
+
+        handlers.JobQueue.tail.subtaskList.tail=null;
+        let spy_deQueue=spy(handlers.JobQueue,"deQueue");
+        assertSinon.notCalled(spy_deQueue);
+    });
+    });
+});

--- a/test/web_socket/handlersTest.spec.js
+++ b/test/web_socket/handlersTest.spec.js
@@ -1,13 +1,14 @@
-
+// imports from test libraries
 import {spy} from "sinon";
 import {assert as assertSinon} from "sinon"
+//websocket imports
+import { WebSocket } from "ws";
+import { WebSocketServer } from "ws";
 
 import { subtaskFeeder } from "../../Jobtypes/matrix_multiplication/taskFeed.js";
 import{JobQueue} from "../../Jobtypes/matrix_multiplication/jobQueue.js";
 import {arr, matrix_B} from "../../Jobtypes/matrix_multiplication/matrixSplit.js"
 
-import { WebSocket } from "ws";
-import { WebSocketServer } from "ws";
 // Udestående: handlers skal importeres frem for defineres i denne fil. Det virker dog ikke umiddelbart. 
 //import {handlers} from "../../web_socket/handlers.js"
 

--- a/test/web_socket/handlersTest.spec.js
+++ b/test/web_socket/handlersTest.spec.js
@@ -1,54 +1,80 @@
+
 import {spy} from "sinon";
 import {assert as assertSinon} from "sinon"
-import {subtaskFeeder} from "../../Jobtypes/matrix_multiplication/taskFeed.js"
+
+import { subtaskFeeder } from "../../Jobtypes/matrix_multiplication/taskFeed.js";
 import{JobQueue} from "../../Jobtypes/matrix_multiplication/jobQueue.js";
-import { WebSocket } from "ws";
-import { WebSocketServer } from "ws";
 import {arr, matrix_B} from "../../Jobtypes/matrix_multiplication/matrixSplit.js"
 
+import { WebSocket } from "ws";
+import { WebSocketServer } from "ws";
+// Udestående: handlers skal importeres frem for defineres i denne fil. Det virker dog ikke umiddelbart. 
+//import {handlers} from "../../web_socket/handlers.js"
+
 let handlers={
-  JobQueue: JobQueue,
-  subtaskFeeder: subtaskFeeder,
-  ws: null,
-  sendSubtask: function sendSubtask(){
-                  //console.log("subtasklist tail:"+JobQueue.tail.subtaskList.tail);
-                  let next_task = handlers.subtaskFeeder(handlers.JobQueue,handlers.ws);
-                  handlers.ws.send(JSON.stringify(next_task));
-                },
-  messageHandler: function messageHandler(message){
-
-                    // Try is for if some one sends somehting which cannot be passed to JSON:
-                    try {
-                    let messageParse = JSON.parse(message);
-                    console.log("Message recieved about this job:");
-                    console.log(
-                      messageParse.jobId
-                      );
-                    } catch (e) {
-                    console.log(`Something went wrong with the recieved message: ${e.message}`);
-                    }
-
-                    try{
-                      handlers.sendSubtask();
-                    } catch (e){
-                    console.log(`Something went wrong with sending message to server: ${e.message}`);
-                    }
-                  },
-connectionHandler: function connectionHandler(ws){
-                      handlers.ws=ws
-                      console.log("New client connected");
-                      console.log("JobQueue: " + JobQueue);
+    subtaskFeeder: subtaskFeeder,
+    ws: null,
+    sendSubtask: function send_subtask() {
+      let next_task = handlers.subtaskFeeder(JobQueue);
+      if (next_task !== null) { //if there is a subtask to send
+        handlers.ws.send(JSON.stringify(next_task));
+      }
+      else{ //if there is no subtask to send
+        console.log("sending 0 to worker")
+        handlers.ws.send("0");
+      }
+    },
+    messageHandler: (message) => { //callback for when a message is recieved from the client
+      // Try is for if some one sends somehting which cannot be passed to JSON:
+      try {
+        let messageParse = JSON.parse(message);
+        
+        if (messageParse["data"] === "ready for work") { //if the worker is ready for work
+        //send_subtask(ws, JobQueue); //send a subtask to the worker
+        
+        }
+        else {
+          let messageParse = JSON.parse(message);
+          console.log("Solution recieved:");
   
-                      if (JobQueue.size > 0) {
-                      
-                      handlers.sendSubtask(ws);
-                      } else {
-                      ws.send("0");
-                      }
+          console.log("jobID: " + messageParse["jobId"]);
+          console.log("taskID: " + messageParse["taskId"]);
+          let currentJob=findJob(messageParse["jobId"]); //find the job in the queue
+          currentJob.solutions[messageParse["taskId"]] = messageParse["solution"]; 
+          currentJob.numOfSolutions++; //increase the number of solutions
+          currentJob.pendingList.removeTask(messageParse["taskId"]); //remove the task from the pending list
+          // console.log("job solutions" + JobQueue.tail.solutions.length);
+          // console.log(messageParse["solution"]);
+        }
+        
+      } catch (e) { //if the message cannot be parsed to JSON
+        console.log(`Something went wrong with the recieved message: ${e.message}`);
+      }
+  
+      try{ //try to send the next subtask
+          handlers.sendSubtask();
+      } catch (e){ //if an error occurs when sending a subtask
+        console.log(`Something went wrong with sending message to server: ${e.message}`);
+      }
+    },
+  connectionHandler: function connectionHandler(ws){//callback for when a new client connects
+    handlers.ws=ws
+    console.log("New client connected");
+    if (JobQueue.size > 0) { //if the queue is not empty, send a subtask to the worker
+    handlers.sendSubtask();
+    } else { //if the queue is empty, send 0 to the worker
+      console.log("sending 0 to worker")
+      ws.send("0");
+    }
+  
+    ws.on("message", handlers.messageHandler)
+  
+    ws.on("close", () => { //when the worker disconnects
+      console.log("Client has disconnected");
+    });
+  }
+  }
 
-                     ws.on("message", handlers.messageHandler)
-                    }
-}
 
 
 describe("handlers", function(){
@@ -149,9 +175,10 @@ describe("handlers", function(){
          JobQueue.head.numOfTasks++;
          }
 
-        handlers.JobQueue.tail.subtaskList.tail=null;
-        let spy_deQueue=spy(handlers.JobQueue,"deQueue");
+        JobQueue.tail.subtaskList.tail=null;
+        let spy_deQueue=spy(JobQueue,"deQueue");
         assertSinon.notCalled(spy_deQueue);
     });
     });
 });
+

--- a/web_socket/handlers.js
+++ b/web_socket/handlers.js
@@ -7,7 +7,7 @@ import { server} from "../server.js";
 
 
 /**
- * websocket handlers
+ * Object: websocket handlers
  * @param ws - websocket connection with the worker (
  * @param JobQueue - Queue of all jobs submitted by buyers
  */

--- a/web_socket/handlers.js
+++ b/web_socket/handlers.js
@@ -1,90 +1,31 @@
-export { startWebsocketserver }
+export { startWebsocketserver , handlers}
+
 import{JobQueue} from "../Jobtypes/matrix_multiplication/jobQueue.js";
 import{subtaskFeeder} from "../Jobtypes/matrix_multiplication/taskFeed.js";
 import { WebSocketServer } from "ws";
 import { server} from "../server.js";
 
+
 /**
- * Sending subtask to the worker
+ * websocket handlers
  * @param ws - websocket connection with the worker (
  * @param JobQueue - Queue of all jobs submitted by buyers
  */
-function send_subtask() {
-  let next_task = subtaskFeeder(JobQueue);
-  if (next_task !== null) { //if there is a subtask to send
-    ws.send(JSON.stringify(next_task));
-  }
-  else{ //if there is no subtask to send
-    console.log("sending 0 to worker")
-    ws.send("0");
-  }
-}
 
 let handlers={
-  JobQueue: JobQueue,
   subtaskFeeder: subtaskFeeder,
   ws: null,
-  sendSubtask: function sendSubtask(){
-                  let next_task = this.subtaskFeeder(this.JobQueue,handlers.ws);
-                   handlers.ws.send(JSON.stringify(next_task));
-                },
-  messageHandler: function messageHandler(message){
-                    // Try is for if some one sends somehting which cannot be passed to JSON:
-                    try {
-                    let messageParse = JSON.parse(message);
-                    console.log("Message recieved:");
-                    console.log(messageParse);
-                    handlers.sendSubtask();
-                    } catch (e){
-                    console.log(`Something went wrong: ${e.message}`);
-                    }
-                  },
-connectionHandler: function connectionHandler(ws){
-                      handlers.ws=ws
-                      console.log("New client connected");
-                      console.log("JobQueue: " + JobQueue);
-  
-                      if (JobQueue.size > 0) {
-                      
-                      handlers.sendSubtask(ws);
-                      } else {
-                      ws.send("0");
-                      }
-
-                     ws.on("message", handlers.messageHandler)
-                    }
-}
-
-
-
-// websocket connection:
-function startWebsocketserver(){
-const wss = new WebSocketServer({ server });
-
-console.log(`There are ${JobQueue.size} jobs in the queue.`);
-
-
-
-
-
-
-
-/**
- * Managing ws communications with worker. Two callbacks
- * on "connection" - frst subtask is sent to the worker
- * on "message" - the solution contained in the message is parsed from string to object, and the next subtask is send.
- */
-wss.on("connection", (ws) => { //callback for when a new client connects
-  console.log("New client connected");
-  console.log("JobQueue: " + JobQueue);
-  if (JobQueue.size > 0) { //if the queue is not empty, send a subtask to the worker
-    send_subtask(ws, JobQueue);
-  } else { //if the queue is empty, send 0 to the worker
-    console.log("sending 0 to worker")
-    ws.send("0");
-  }
-
-  ws.on("message", (message) => { //callback for when a message is recieved from the client
+  sendSubtask: function send_subtask() {
+    let next_task = handlers.subtaskFeeder(JobQueue);
+    if (next_task !== null) { //if there is a subtask to send
+      handlers.ws.send(JSON.stringify(next_task));
+    }
+    else{ //if there is no subtask to send
+      console.log("sending 0 to worker")
+      handlers.ws.send("0");
+    }
+  },
+  messageHandler: (message) => { //callback for when a message is recieved from the client
     // Try is for if some one sends somehting which cannot be passed to JSON:
     try {
       let messageParse = JSON.parse(message);
@@ -112,24 +53,42 @@ wss.on("connection", (ws) => { //callback for when a new client connects
     }
 
     try{ //try to send the next subtask
-        send_subtask(ws, JobQueue);
+        handlers.sendSubtask();
     } catch (e){ //if an error occurs when sending a subtask
       console.log(`Something went wrong with sending message to server: ${e.message}`);
     }
-  });
+  },
+connectionHandler: function connectionHandler(ws){//callback for when a new client connects
+  handlers.ws=ws
+  console.log("New client connected");
+  if (JobQueue.size > 0) { //if the queue is not empty, send a subtask to the worker
+  handlers.sendSubtask();
+  } else { //if the queue is empty, send 0 to the worker
+    console.log("sending 0 to worker")
+    ws.send("0");
+  }
+
+  ws.on("message", handlers.messageHandler)
 
   ws.on("close", () => { //when the worker disconnects
     console.log("Client has disconnected");
   });
+}
+}
 
-})};
+function startWebsocketserver(){
+  const wss = new WebSocketServer({ server });
+  console.log(`There are ${JobQueue.size} jobs in the queue.`);
 
+  wss.on("connection",handlers.connectionHandler); 
+};
 
 /**
  * Function to find a job in the queue by its jobId
  * @param {number} jobId 
  * @returns the job with the given jobId
- */
+ **/
+
 function findJob(jobId){
   let currentJob=JobQueue.tail;
   if (currentJob.jobId==jobId){
@@ -140,3 +99,4 @@ function findJob(jobId){
   }
   return currentJob.previous;
 }
+


### PR DESCRIPTION
Der er 2 test af websocket handlers for nu. Objektet er indført pga. brugen af sinon spies i testene. Der har vi nemlig brug for at de funktioner der "spioneres" på er metoder i et objekt. Der er sikkert en anden løsning, men dette blev altså lige løsningen for nu. 

handlers-objekt'et er defineret i test-filen frem for at importere den fra handlers.js. Den bør blive importeret, men umiddelbart medfører importering en error når man kører "npm test" som jeg ikke forstår. Jeg har ladet dette problem ligge for nu, da der er andre ting der skal gøres. Det fungerer som det er nu, men det er en lappeløsning af definere handlers-objektet i test-filen. 

Der er blevet tilføjet yderligere to tests af matrix_mult-funktionen. 

Jeg har testet at kommunikationen med workeren virker med den nye version af handlers.js (med objektet). Når der uploades et job beynder workeren at regne subtask'ene i jobbet som den skal. 